### PR TITLE
Admin-Dashboard um leichte Live-Ops-Ansicht ergänzt

### DIFF
--- a/bfs-backend/internal/api/handlers.go
+++ b/bfs-backend/internal/api/handlers.go
@@ -17,6 +17,7 @@ type Handlers struct {
 	generated.Unimplemented
 
 	categories    service.CategoryService
+	dashboard     service.DashboardService
 	products      service.ProductService
 	orders        service.OrderService
 	payments      service.PaymentService
@@ -47,6 +48,7 @@ type HandlersDeps struct {
 
 	Config        config.Config
 	Categories    service.CategoryService
+	Dashboard     service.DashboardService
 	Products      service.ProductService
 	Orders        service.OrderService
 	Payments      service.PaymentService
@@ -71,6 +73,7 @@ type HandlersDeps struct {
 func NewHandlers(deps HandlersDeps) *Handlers {
 	return &Handlers{
 		categories:           deps.Categories,
+		dashboard:            deps.Dashboard,
 		products:             deps.Products,
 		orders:               deps.Orders,
 		payments:             deps.Payments,

--- a/bfs-backend/internal/api/handlers_admin_dashboard.go
+++ b/bfs-backend/internal/api/handlers_admin_dashboard.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+
+	"backend/internal/response"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func (h *Handlers) GetAdminOpsOverview(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.dashboard.GetOpsOverview(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "ops_overview_failed", err.Error())
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, summary)
+}
+
+func (h *Handlers) GetAdminStationSummary(w http.ResponseWriter, r *http.Request) {
+	stationID, err := uuid.Parse(chi.URLParam(r, "stationId"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_station_id", "Ungültige Station.")
+		return
+	}
+
+	summary, err := h.dashboard.GetStationDetail(r.Context(), stationID)
+	if err != nil {
+		writeEntError(w, err)
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, summary)
+}

--- a/bfs-backend/internal/app/services.go
+++ b/bfs-backend/internal/app/services.go
@@ -13,6 +13,7 @@ func NewServices() fx.Option {
 		fx.Provide(
 			service.NewPaymentService,
 			service.NewSettingsService,
+			service.NewDashboardService,
 			service.NewProductService,
 			service.NewCategoryService,
 			service.NewOrderService,

--- a/bfs-backend/internal/http/router.go
+++ b/bfs-backend/internal/http/router.go
@@ -173,6 +173,8 @@ func NewRouter(
 
 			admin.Get("/settings", wrapper.GetSettings)
 			admin.Patch("/settings", wrapper.UpdateSettings)
+			admin.Get("/dashboard/ops-overview", apiHandlers.GetAdminOpsOverview)
+			admin.Get("/stations/{stationId}/summary", apiHandlers.GetAdminStationSummary)
 
 			admin.Get("/jetons", wrapper.ListJetons)
 			admin.Post("/jetons", wrapper.CreateJeton)

--- a/bfs-backend/internal/service/admin_dashboard.go
+++ b/bfs-backend/internal/service/admin_dashboard.go
@@ -1,0 +1,518 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"backend/internal/generated/ent"
+	"backend/internal/generated/ent/device"
+	"backend/internal/generated/ent/order"
+	"backend/internal/generated/ent/orderline"
+	"backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+const dashboardTopProductWindow = time.Hour
+
+type DashboardStatusLevel string
+
+const (
+	DashboardStatusGreen  DashboardStatusLevel = "green"
+	DashboardStatusYellow DashboardStatusLevel = "yellow"
+	DashboardStatusRed    DashboardStatusLevel = "red"
+)
+
+type SystemStatusChip struct {
+	Key     string               `json:"key"`
+	Label   string               `json:"label"`
+	Status  DashboardStatusLevel `json:"status"`
+	Summary string               `json:"summary"`
+}
+
+type StationOverviewCard struct {
+	ID                      string               `json:"id"`
+	Name                    string               `json:"name"`
+	Status                  DashboardStatusLevel `json:"status"`
+	OpenOrders              int                  `json:"openOrders"`
+	Backlog                 int                  `json:"backlog"`
+	MedianThroughputMinutes int                  `json:"medianThroughputMinutes"`
+	RecentProductTitle      *string              `json:"recentProductTitle,omitempty"`
+	RecentProductQuantity   int                  `json:"recentProductQuantity"`
+}
+
+type AdminOpsOverview struct {
+	OverallStatus DashboardStatusLevel  `json:"overallStatus"`
+	StatusChips   []SystemStatusChip    `json:"statusChips"`
+	Stations      []StationOverviewCard `json:"stations"`
+}
+
+type DashboardTopProductWindowItem struct {
+	Title        string `json:"title"`
+	Quantity     int    `json:"quantity"`
+	RevenueCents int64  `json:"revenueCents"`
+}
+
+type DashboardSeriesPoint struct {
+	Label string `json:"label"`
+	Value int64  `json:"value"`
+}
+
+type StationQueueMetric struct {
+	OrderID         string   `json:"orderId"`
+	CreatedAt       string   `json:"createdAt"`
+	AgeMinutes      int      `json:"ageMinutes"`
+	PendingItems    int      `json:"pendingItems"`
+	PendingQuantity int      `json:"pendingQuantity"`
+	Titles          []string `json:"titles"`
+}
+
+type StationDetailSummary struct {
+	Station          StationOverviewCard             `json:"station"`
+	Queue            []StationQueueMetric            `json:"queue"`
+	TopProducts      []DashboardTopProductWindowItem `json:"topProducts"`
+	ThroughputByHour []DashboardSeriesPoint          `json:"throughputByHour"`
+}
+
+type DashboardService interface {
+	GetOpsOverview(ctx context.Context) (*AdminOpsOverview, error)
+	GetStationDetail(ctx context.Context, stationID uuid.UUID) (*StationDetailSummary, error)
+}
+
+type dashboardService struct {
+	client   *ent.Client
+	devices  repository.DeviceRepository
+	settings SettingsService
+	payments PaymentService
+	stations StationService
+}
+
+func NewDashboardService(
+	client *ent.Client,
+	devices repository.DeviceRepository,
+	settings SettingsService,
+	payments PaymentService,
+	stations StationService,
+) DashboardService {
+	return &dashboardService{
+		client:   client,
+		devices:  devices,
+		settings: settings,
+		payments: payments,
+		stations: stations,
+	}
+}
+
+func (s *dashboardService) GetOpsOverview(ctx context.Context) (*AdminOpsOverview, error) {
+	windowStart, windowEnd := currentOpsWindow()
+
+	windowOrders, err := s.loadOrders(ctx, windowStart, windowEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	stations, err := s.stations.ListStations(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	stationCards := buildStationCards(stations, windowOrders, windowEnd)
+	statusChips, overallStatus, err := s.buildStatusChips(ctx, stationCards)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AdminOpsOverview{
+		OverallStatus: overallStatus,
+		StatusChips:   statusChips,
+		Stations:      stationCards,
+	}, nil
+}
+
+func (s *dashboardService) GetStationDetail(ctx context.Context, stationID uuid.UUID) (*StationDetailSummary, error) {
+	windowStart, windowEnd := currentOpsWindow()
+
+	windowOrders, err := s.loadOrders(ctx, windowStart, windowEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	station, err := s.stations.GetStationByID(ctx, stationID)
+	if err != nil {
+		return nil, err
+	}
+
+	productIDs := stationProductIDs(station)
+	card, queue, throughput := buildSingleStationMetrics(station, productIDs, windowOrders, windowEnd)
+
+	return &StationDetailSummary{
+		Station:          card,
+		Queue:            queue,
+		TopProducts:      buildStationTopProducts(productIDs, windowOrders, windowEnd),
+		ThroughputByHour: throughput,
+	}, nil
+}
+
+func currentOpsWindow() (time.Time, time.Time) {
+	loc := swissLocation()
+	now := time.Now().In(loc)
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	return start, now
+}
+
+func (s *dashboardService) loadOrders(ctx context.Context, from, to time.Time) ([]*ent.Order, error) {
+	return s.client.Order.Query().
+		Where(
+			order.CreatedAtGTE(from),
+			order.CreatedAtLT(to),
+		).
+		WithPayments().
+		WithLines(func(q *ent.OrderLineQuery) {
+			q.WithRedemption()
+		}).
+		Order(order.ByCreatedAt()).
+		All(ctx)
+}
+
+func (s *dashboardService) buildStatusChips(ctx context.Context, stationCards []StationOverviewCard) ([]SystemStatusChip, DashboardStatusLevel, error) {
+	systemEnabled, err := s.settings.IsSystemEnabled(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	posDevices, err := s.devices.GetByType(ctx, device.TypePOS)
+	if err != nil {
+		return nil, "", err
+	}
+	stationDevices, err := s.devices.GetByType(ctx, device.TypeSTATION)
+	if err != nil {
+		return nil, "", err
+	}
+
+	chips := buildOpsStatusChips(systemEnabled, s.payments.IsPayrexxEnabled(), posDevices, stationDevices, stationCards)
+	return chips, overallStatusOf(chips), nil
+}
+
+func buildOpsStatusChips(
+	systemEnabled bool,
+	payrexxEnabled bool,
+	posDevices []*ent.Device,
+	stationDevices []*ent.Device,
+	stationCards []StationOverviewCard,
+) []SystemStatusChip {
+	posApproved, posPending := countDevices(posDevices)
+	stationApproved, stationPending := countDevices(stationDevices)
+	redStations, yellowStations, _ := stationPressure(stationCards)
+
+	systemStatus := DashboardStatusGreen
+	systemSummary := "System geöffnet"
+	if !systemEnabled {
+		systemStatus = DashboardStatusRed
+		systemSummary = "System geschlossen"
+	}
+
+	paymentStatus := DashboardStatusGreen
+	paymentSummary := "TWINT/Webhook bereit"
+	if !payrexxEnabled {
+		paymentStatus = DashboardStatusYellow
+		paymentSummary = "TWINT nicht konfiguriert"
+	}
+
+	posStatus := DashboardStatusGreen
+	posSummary := fmt.Sprintf("%d POS aktiv", posApproved)
+	if posApproved == 0 {
+		posStatus = DashboardStatusRed
+		posSummary = "Kein POS freigegeben"
+	} else if posPending > 0 {
+		posStatus = DashboardStatusYellow
+		posSummary = fmt.Sprintf("%d POS aktiv, %d ausstehend", posApproved, posPending)
+	}
+
+	stationStatus := DashboardStatusGreen
+	stationSummary := fmt.Sprintf("%d Stationen aktiv", stationApproved)
+	if stationApproved == 0 {
+		stationStatus = DashboardStatusRed
+		stationSummary = "Keine Station freigegeben"
+	} else if redStations > 0 {
+		stationStatus = DashboardStatusRed
+		stationSummary = fmt.Sprintf("%d Stationen kritisch", redStations)
+	} else if yellowStations > 0 {
+		stationStatus = DashboardStatusYellow
+		stationSummary = fmt.Sprintf("%d Stationen beobachten", yellowStations)
+	} else if stationPending > 0 {
+		stationStatus = DashboardStatusYellow
+		stationSummary = fmt.Sprintf("%d Stationen aktiv, %d ausstehend", stationApproved, stationPending)
+	}
+
+	return []SystemStatusChip{
+		{Key: "system", Label: "System", Status: systemStatus, Summary: systemSummary},
+		{Key: "payments", Label: "Payments", Status: paymentStatus, Summary: paymentSummary},
+		{Key: "pos", Label: "POS", Status: posStatus, Summary: posSummary},
+		{Key: "stations", Label: "Stationen", Status: stationStatus, Summary: stationSummary},
+	}
+}
+
+func overallStatusOf(chips []SystemStatusChip) DashboardStatusLevel {
+	overall := DashboardStatusGreen
+	for _, chip := range chips {
+		if chip.Status == DashboardStatusRed {
+			return DashboardStatusRed
+		}
+		if chip.Status == DashboardStatusYellow {
+			overall = DashboardStatusYellow
+		}
+	}
+	return overall
+}
+
+func stationPressure(cards []StationOverviewCard) (red int, yellow int, openOrders int) {
+	for _, card := range cards {
+		openOrders += card.OpenOrders
+		switch card.Status {
+		case DashboardStatusRed:
+			red++
+		case DashboardStatusYellow:
+			yellow++
+		}
+	}
+	return red, yellow, openOrders
+}
+
+func buildStationCards(stations []*ent.Device, orders []*ent.Order, windowEnd time.Time) []StationOverviewCard {
+	cards := make([]StationOverviewCard, 0, len(stations))
+	for _, station := range stations {
+		if station.Status != device.StatusApproved {
+			continue
+		}
+		card, _, _ := buildSingleStationMetrics(station, stationProductIDs(station), orders, windowEnd)
+		cards = append(cards, card)
+	}
+
+	sort.Slice(cards, func(i, j int) bool {
+		if cards[i].Status != cards[j].Status {
+			return severityRank(cards[i].Status) > severityRank(cards[j].Status)
+		}
+		if cards[i].OpenOrders != cards[j].OpenOrders {
+			return cards[i].OpenOrders > cards[j].OpenOrders
+		}
+		return cards[i].Name < cards[j].Name
+	})
+
+	return cards
+}
+
+func buildSingleStationMetrics(station *ent.Device, productIDs map[uuid.UUID]struct{}, orders []*ent.Order, windowEnd time.Time) (StationOverviewCard, []StationQueueMetric, []DashboardSeriesPoint) {
+	queueByOrder := map[uuid.UUID]*StationQueueMetric{}
+	var throughputMinutes []int
+	recentProducts := map[string]int{}
+	recentStart := windowEnd.Add(-dashboardTopProductWindow)
+	redeemedByHour := map[string]int64{}
+	loc := swissLocation()
+
+	for _, ord := range orders {
+		if ord.Status != order.StatusPaid {
+			continue
+		}
+		for _, line := range flattenOrderLines(ord.Edges.Lines) {
+			if _, ok := productIDs[line.ProductID]; !ok {
+				continue
+			}
+
+			if ord.CreatedAt.After(recentStart) {
+				recentProducts[line.Title] += line.Quantity
+			}
+
+			if line.Edges.Redemption == nil {
+				entry := queueByOrder[ord.ID]
+				if entry == nil {
+					entry = &StationQueueMetric{
+						OrderID:    ord.ID.String(),
+						CreatedAt:  ord.CreatedAt.Format(time.RFC3339),
+						AgeMinutes: maxInt(0, int(windowEnd.Sub(ord.CreatedAt).Minutes())),
+					}
+					queueByOrder[ord.ID] = entry
+				}
+				entry.PendingItems++
+				entry.PendingQuantity += line.Quantity
+				entry.Titles = append(entry.Titles, line.Title)
+				continue
+			}
+
+			minutes := int(line.Edges.Redemption.RedeemedAt.Sub(ord.CreatedAt).Minutes())
+			if minutes >= 0 {
+				throughputMinutes = append(throughputMinutes, minutes)
+			}
+			hourLabel := line.Edges.Redemption.RedeemedAt.In(loc).Format("15:00")
+			redeemedByHour[hourLabel] += int64(line.Quantity)
+		}
+	}
+
+	queue := make([]StationQueueMetric, 0, len(queueByOrder))
+	for _, entry := range queueByOrder {
+		queue = append(queue, *entry)
+	}
+	sort.Slice(queue, func(i, j int) bool {
+		if queue[i].AgeMinutes != queue[j].AgeMinutes {
+			return queue[i].AgeMinutes > queue[j].AgeMinutes
+		}
+		return queue[i].OrderID < queue[j].OrderID
+	})
+
+	var topTitle *string
+	topQty := 0
+	for title, qty := range recentProducts {
+		if qty > topQty {
+			copyTitle := title
+			topTitle = &copyTitle
+			topQty = qty
+		}
+	}
+
+	median := medianInt(throughputMinutes)
+	openOrders := len(queue)
+	status := stationSeverity(openOrders, median)
+
+	points := make([]DashboardSeriesPoint, 0, len(redeemedByHour))
+	for label, value := range redeemedByHour {
+		points = append(points, DashboardSeriesPoint{Label: label, Value: value})
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].Label < points[j].Label })
+
+	return StationOverviewCard{
+		ID:                      station.ID.String(),
+		Name:                    station.Name,
+		Status:                  status,
+		OpenOrders:              openOrders,
+		Backlog:                 openOrders,
+		MedianThroughputMinutes: median,
+		RecentProductTitle:      topTitle,
+		RecentProductQuantity:   topQty,
+	}, queue, points
+}
+
+func buildStationTopProducts(productIDs map[uuid.UUID]struct{}, orders []*ent.Order, windowEnd time.Time) []DashboardTopProductWindowItem {
+	recentStart := windowEnd.Add(-dashboardTopProductWindow)
+	type agg struct {
+		qty     int
+		revenue int64
+	}
+	byTitle := map[string]*agg{}
+
+	for _, ord := range orders {
+		if ord.Status != order.StatusPaid || ord.CreatedAt.Before(recentStart) {
+			continue
+		}
+		for _, line := range flattenOrderLines(ord.Edges.Lines) {
+			if _, ok := productIDs[line.ProductID]; !ok {
+				continue
+			}
+			entry := byTitle[line.Title]
+			if entry == nil {
+				entry = &agg{}
+				byTitle[line.Title] = entry
+			}
+			entry.qty += line.Quantity
+			entry.revenue += line.UnitPriceCents * int64(line.Quantity)
+		}
+	}
+
+	items := make([]DashboardTopProductWindowItem, 0, len(byTitle))
+	for title, entry := range byTitle {
+		items = append(items, DashboardTopProductWindowItem{
+			Title:        title,
+			Quantity:     entry.qty,
+			RevenueCents: entry.revenue,
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Quantity != items[j].Quantity {
+			return items[i].Quantity > items[j].Quantity
+		}
+		return items[i].RevenueCents > items[j].RevenueCents
+	})
+	if len(items) > 6 {
+		items = items[:6]
+	}
+	return items
+}
+
+func stationProductIDs(station *ent.Device) map[uuid.UUID]struct{} {
+	productIDs := make(map[uuid.UUID]struct{})
+	for _, dp := range station.Edges.DeviceProducts {
+		productIDs[dp.ProductID] = struct{}{}
+	}
+	return productIDs
+}
+
+func flattenOrderLines(lines []*ent.OrderLine) []*ent.OrderLine {
+	out := make([]*ent.OrderLine, 0, len(lines))
+	for _, line := range lines {
+		if line.LineType != orderline.LineTypeBundle {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func countDevices(devices []*ent.Device) (approved int, pending int) {
+	for _, dev := range devices {
+		switch dev.Status {
+		case device.StatusApproved:
+			approved++
+		case device.StatusPending:
+			pending++
+		}
+	}
+	return approved, pending
+}
+
+func stationSeverity(openOrders, medianMinutes int) DashboardStatusLevel {
+	if openOrders >= 8 || medianMinutes >= 25 {
+		return DashboardStatusRed
+	}
+	if openOrders >= 3 || medianMinutes >= 12 {
+		return DashboardStatusYellow
+	}
+	return DashboardStatusGreen
+}
+
+func severityRank(level DashboardStatusLevel) int {
+	switch level {
+	case DashboardStatusRed:
+		return 3
+	case DashboardStatusYellow:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func medianInt(values []int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	cp := append([]int(nil), values...)
+	sort.Ints(cp)
+	mid := len(cp) / 2
+	if len(cp)%2 == 1 {
+		return cp[mid]
+	}
+	return (cp[mid-1] + cp[mid]) / 2
+}
+
+func swissLocation() *time.Location {
+	loc, err := time.LoadLocation("Europe/Zurich")
+	if err != nil {
+		return time.Local
+	}
+	return loc
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/bfs-backend/internal/service/admin_dashboard_test.go
+++ b/bfs-backend/internal/service/admin_dashboard_test.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"backend/internal/generated/ent"
+	"backend/internal/generated/ent/device"
+	"backend/internal/generated/ent/order"
+
+	"github.com/google/uuid"
+)
+
+func TestBuildOpsStatusChipsSystemClosedRed(t *testing.T) {
+	chips := buildOpsStatusChips(
+		false,
+		true,
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypePOS}},
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypeSTATION}},
+		nil,
+	)
+
+	if chip := chipByKey(chips, "system"); chip == nil || chip.Status != DashboardStatusRed {
+		t.Fatalf("expected system chip to be red, got %#v", chip)
+	}
+	if overall := overallStatusOf(chips); overall != DashboardStatusRed {
+		t.Fatalf("expected overall status red, got %q", overall)
+	}
+}
+
+func TestBuildOpsStatusChipsPayrexxDisabledYellow(t *testing.T) {
+	chips := buildOpsStatusChips(
+		true,
+		false,
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypePOS}},
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypeSTATION}},
+		nil,
+	)
+
+	if chip := chipByKey(chips, "payments"); chip == nil || chip.Status != DashboardStatusYellow {
+		t.Fatalf("expected payments chip to be yellow, got %#v", chip)
+	}
+	if overall := overallStatusOf(chips); overall != DashboardStatusYellow {
+		t.Fatalf("expected overall status yellow, got %q", overall)
+	}
+}
+
+func TestBuildOpsStatusChipsNoApprovedPOSRed(t *testing.T) {
+	chips := buildOpsStatusChips(
+		true,
+		true,
+		nil,
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypeSTATION}},
+		nil,
+	)
+
+	if chip := chipByKey(chips, "pos"); chip == nil || chip.Status != DashboardStatusRed {
+		t.Fatalf("expected pos chip to be red, got %#v", chip)
+	}
+}
+
+func TestBuildOpsStatusChipsStationPressureRed(t *testing.T) {
+	chips := buildOpsStatusChips(
+		true,
+		true,
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypePOS}},
+		[]*ent.Device{{Status: device.StatusApproved, Type: device.TypeSTATION}},
+		[]StationOverviewCard{{Status: DashboardStatusRed, OpenOrders: 9}},
+	)
+
+	if chip := chipByKey(chips, "stations"); chip == nil || chip.Status != DashboardStatusRed {
+		t.Fatalf("expected stations chip to be red, got %#v", chip)
+	}
+}
+
+func TestBuildSingleStationMetricsCountsQueueAndThroughput(t *testing.T) {
+	loc := swissLocation()
+	windowEnd := time.Date(2026, 4, 27, 11, 0, 0, 0, loc)
+	stationID := uuid.MustParse("01900000-0000-7000-8000-000000000001")
+	productID := uuid.MustParse("01900000-0000-7000-8000-000000000101")
+	otherProductID := uuid.MustParse("01900000-0000-7000-8000-000000000102")
+
+	orderOneID := uuid.MustParse("01900000-0000-7000-8000-000000000201")
+	orderTwoID := uuid.MustParse("01900000-0000-7000-8000-000000000202")
+
+	queueLineID := uuid.MustParse("01900000-0000-7000-8000-000000000301")
+	redeemedLineOneID := uuid.MustParse("01900000-0000-7000-8000-000000000302")
+	redeemedLineTwoID := uuid.MustParse("01900000-0000-7000-8000-000000000303")
+	ignoredLineID := uuid.MustParse("01900000-0000-7000-8000-000000000304")
+
+	orders := []*ent.Order{
+		{
+			ID:        orderOneID,
+			Status:    order.StatusPaid,
+			CreatedAt: time.Date(2026, 4, 27, 10, 15, 0, 0, loc),
+			Edges: ent.OrderEdges{Lines: []*ent.OrderLine{
+				{
+					ID:             queueLineID,
+					OrderID:        orderOneID,
+					ProductID:      productID,
+					Title:          "Fries",
+					Quantity:       2,
+					UnitPriceCents: 900,
+				},
+			}},
+		},
+		{
+			ID:        orderTwoID,
+			Status:    order.StatusPaid,
+			CreatedAt: time.Date(2026, 4, 27, 9, 30, 0, 0, loc),
+			Edges: ent.OrderEdges{Lines: []*ent.OrderLine{
+				{
+					ID:             redeemedLineOneID,
+					OrderID:        orderTwoID,
+					ProductID:      productID,
+					Title:          "Fries",
+					Quantity:       1,
+					UnitPriceCents: 450,
+					Edges: ent.OrderLineEdges{Redemption: &ent.OrderLineRedemption{
+						OrderLineID: redeemedLineOneID,
+						RedeemedAt:  time.Date(2026, 4, 27, 9, 42, 0, 0, loc),
+					}},
+				},
+				{
+					ID:             redeemedLineTwoID,
+					OrderID:        orderTwoID,
+					ProductID:      productID,
+					Title:          "Fries",
+					Quantity:       3,
+					UnitPriceCents: 1350,
+					Edges: ent.OrderLineEdges{Redemption: &ent.OrderLineRedemption{
+						OrderLineID: redeemedLineTwoID,
+						RedeemedAt:  time.Date(2026, 4, 27, 9, 50, 0, 0, loc),
+					}},
+				},
+				{
+					ID:             ignoredLineID,
+					OrderID:        orderTwoID,
+					ProductID:      otherProductID,
+					Title:          "Salad",
+					Quantity:       5,
+					UnitPriceCents: 700,
+				},
+			}},
+		},
+	}
+
+	card, queue, throughput := buildSingleStationMetrics(
+		&ent.Device{ID: stationID, Name: "Fryer", Status: device.StatusApproved},
+		map[uuid.UUID]struct{}{productID: {}},
+		orders,
+		windowEnd,
+	)
+
+	if card.OpenOrders != 1 || card.Backlog != 1 {
+		t.Fatalf("expected 1 open order/backlog, got %d/%d", card.OpenOrders, card.Backlog)
+	}
+	if card.MedianThroughputMinutes != 16 {
+		t.Fatalf("expected median throughput 16, got %d", card.MedianThroughputMinutes)
+	}
+	if card.Status != DashboardStatusYellow {
+		t.Fatalf("expected yellow station status, got %q", card.Status)
+	}
+	if card.RecentProductTitle == nil || *card.RecentProductTitle != "Fries" || card.RecentProductQuantity != 2 {
+		t.Fatalf("expected recent product Fries x2, got %#v / %d", card.RecentProductTitle, card.RecentProductQuantity)
+	}
+
+	if len(queue) != 1 {
+		t.Fatalf("expected one queued order, got %d", len(queue))
+	}
+	if queue[0].OrderID != orderOneID.String() || queue[0].PendingItems != 1 || queue[0].PendingQuantity != 2 {
+		t.Fatalf("unexpected queue metrics: %#v", queue[0])
+	}
+
+	if len(throughput) != 1 || throughput[0].Label != "09:00" || throughput[0].Value != 4 {
+		t.Fatalf("unexpected throughput series: %#v", throughput)
+	}
+}
+
+func TestBuildStationTopProductsUsesLastHourOnly(t *testing.T) {
+	loc := swissLocation()
+	windowEnd := time.Date(2026, 4, 27, 11, 0, 0, 0, loc)
+	productID := uuid.MustParse("01900000-0000-7000-8000-000000000101")
+	orderRecentID := uuid.MustParse("01900000-0000-7000-8000-000000000201")
+	orderOldID := uuid.MustParse("01900000-0000-7000-8000-000000000202")
+
+	orders := []*ent.Order{
+		{
+			ID:        orderRecentID,
+			Status:    order.StatusPaid,
+			CreatedAt: time.Date(2026, 4, 27, 10, 30, 0, 0, loc),
+			Edges: ent.OrderEdges{Lines: []*ent.OrderLine{
+				{
+					OrderID:        orderRecentID,
+					ProductID:      productID,
+					Title:          "Burger",
+					Quantity:       2,
+					UnitPriceCents: 1200,
+				},
+			}},
+		},
+		{
+			ID:        orderOldID,
+			Status:    order.StatusPaid,
+			CreatedAt: time.Date(2026, 4, 27, 8, 30, 0, 0, loc),
+			Edges: ent.OrderEdges{Lines: []*ent.OrderLine{
+				{
+					OrderID:        orderOldID,
+					ProductID:      productID,
+					Title:          "Burger",
+					Quantity:       7,
+					UnitPriceCents: 1200,
+				},
+			}},
+		},
+	}
+
+	items := buildStationTopProducts(map[uuid.UUID]struct{}{productID: {}}, orders, windowEnd)
+
+	if len(items) != 1 {
+		t.Fatalf("expected one top-product entry, got %d", len(items))
+	}
+	if items[0].Title != "Burger" || items[0].Quantity != 2 || items[0].RevenueCents != 2400 {
+		t.Fatalf("unexpected top-product entry: %#v", items[0])
+	}
+}
+
+func chipByKey(chips []SystemStatusChip, key string) *SystemStatusChip {
+	for _, chip := range chips {
+		if chip.Key == key {
+			copyChip := chip
+			return &copyChip
+		}
+	}
+	return nil
+}

--- a/bfs-web-app/app/admin/page.tsx
+++ b/bfs-web-app/app/admin/page.tsx
@@ -1,11 +1,15 @@
 "use client"
 
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ArrowRight, RadioTower } from "lucide-react"
 import Image from "next/image"
+import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
-import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useAuthorizedFetch } from "@/hooks/use-authorized-fetch"
-import { formatChf } from "@/lib/utils"
+import { cn, formatChf } from "@/lib/utils"
+import type { AdminOpsOverview, DashboardStatusLevel } from "@/types"
 import { OrdersByOriginChart } from "./_components/orders-by-origin-chart"
 import { OrdersByStatusChart } from "./_components/orders-by-status-chart"
 import { PaymentMethodsChart } from "./_components/payment-methods-chart"
@@ -75,6 +79,32 @@ function isGratisMethod(method?: string) {
   return method?.startsWith("GRATIS_") ?? false
 }
 
+function eventKey(event: EventDay) {
+  return `${event.year}-${String(event.month).padStart(2, "0")}-${String(event.day).padStart(2, "0")}`
+}
+
+function formatEventLabel(event: EventDay | undefined) {
+  if (!event) return "–"
+  return new Date(event.year, event.month - 1, event.day).toLocaleDateString("de-CH", {
+    weekday: "short",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  })
+}
+
+function statusClasses(status: DashboardStatusLevel) {
+  if (status === "red") return "border-red-300 bg-red-50 text-red-800"
+  if (status === "yellow") return "border-amber-300 bg-amber-50 text-amber-900"
+  return "border-emerald-300 bg-emerald-50 text-emerald-900"
+}
+
+function severityCopy(status: DashboardStatusLevel) {
+  if (status === "red") return "Kritisch"
+  if (status === "yellow") return "Beobachten"
+  return "Stabil"
+}
+
 export default function AdminDashboard() {
   const fetchAuth = useAuthorizedFetch()
   const [error, setError] = useState<string | null>(null)
@@ -85,8 +115,12 @@ export default function AdminDashboard() {
   const [products, setProducts] = useState<ProductWithStock[]>([])
 
   const [events, setEvents] = useState<EventDay[]>([])
-  const [currentEventIndex, setCurrentEventIndex] = useState(0)
+  const [selectedEventKey, setSelectedEventKey] = useState("")
   const [eventsLoading, setEventsLoading] = useState(true)
+
+  const [opsOverview, setOpsOverview] = useState<AdminOpsOverview | null>(null)
+  const [opsLoading, setOpsLoading] = useState(true)
+  const [opsError, setOpsError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -96,7 +130,9 @@ export default function AdminDashboard() {
       .then((data) => {
         if (!cancelled) {
           const typedData = data as { items?: EventDay[] }
-          setEvents(typedData.items || [])
+          const nextEvents = typedData.items || []
+          setEvents(nextEvents)
+          setSelectedEventKey((current) => current || (nextEvents[0] ? eventKey(nextEvents[0]) : ""))
           setEventsLoading(false)
         }
       })
@@ -111,24 +147,58 @@ export default function AdminDashboard() {
   }, [fetchAuth])
 
   useEffect(() => {
+    let cancelled = false
+    setOpsLoading(true)
+    setOpsError(null)
+
+    fetchAuth("/api/v1/dashboard/ops-overview")
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data) => {
+        if (!cancelled) {
+          setOpsOverview(data as AdminOpsOverview)
+          setOpsLoading(false)
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setOpsOverview(null)
+          setOpsError(err instanceof Error ? err.message : "Live-Betrieb konnte nicht geladen werden.")
+          setOpsLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetchAuth])
+
+  useEffect(() => {
     if (events.length === 0) {
       setLoading(false)
       return
     }
-    const event = events[currentEventIndex]
+
+    const currentIndex = Math.max(
+      0,
+      events.findIndex((event) => eventKey(event) === selectedEventKey)
+    )
+    const event = events[currentIndex]
     if (!event) {
       setLoading(false)
       return
     }
+
     let cancelled = false
     setLoading(true)
+    setError(null)
+
     ;(async () => {
       try {
         const from = new Date(event.year, event.month - 1, event.day)
         const to = new Date(event.year, event.month - 1, event.day + 1)
         const dateParams = `date_from=${encodeURIComponent(from.toISOString())}&date_to=${encodeURIComponent(to.toISOString())}`
 
-        const prevEvent = events[currentEventIndex + 1]
+        const prevEvent = events[currentIndex + 1]
         const prevDateParams = prevEvent
           ? `date_from=${encodeURIComponent(new Date(prevEvent.year, prevEvent.month - 1, prevEvent.day).toISOString())}&date_to=${encodeURIComponent(new Date(prevEvent.year, prevEvent.month - 1, prevEvent.day + 1).toISOString())}`
           : null
@@ -172,12 +242,11 @@ export default function AdminDashboard() {
         }
       }
     })()
+
     return () => {
       cancelled = true
     }
-  }, [fetchAuth, events, currentEventIndex])
-
-  // --- Derived data ---
+  }, [fetchAuth, events, selectedEventKey])
 
   const paidOrders = useMemo(() => orders.filter((o) => o.status === "paid"), [orders])
 
@@ -340,17 +409,6 @@ export default function AdminDashboard() {
       .slice(0, 10)
   }, [products])
 
-  const currentEventLabel = useMemo(() => {
-    if (events.length === 0) return "–"
-    const event = events[currentEventIndex]
-    if (!event) return "–"
-    return new Date(event.year, event.month - 1, event.day).toLocaleDateString("de-CH", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    })
-  }, [events, currentEventIndex])
-
   function comparisonLabel(current: number, previous: number): { label: string; positive: boolean } | null {
     if (previous === 0) return null
     const delta = current - previous
@@ -360,36 +418,141 @@ export default function AdminDashboard() {
   }
 
   const hasPrevDay = prevDayOrders.length > 0
+  const selectedEvent = events.find((event) => eventKey(event) === selectedEventKey) || events[0]
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Adminbereich</h1>
-      {error && <div className="text-sm text-red-600">{error}</div>}
-
-      <div className="flex items-center gap-3">
-        <span className="text-muted-foreground text-sm">Zeitraum:</span>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => setCurrentEventIndex((i) => i + 1)}
-            disabled={eventsLoading || currentEventIndex >= events.length - 1}
-          >
-            <ChevronLeft className="size-4" />
-          </Button>
-          <span className="min-w-[160px] text-center font-medium">{currentEventLabel}</span>
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => setCurrentEventIndex((i) => i - 1)}
-            disabled={eventsLoading || currentEventIndex === 0}
-          >
-            <ChevronRight className="size-4" />
-          </Button>
-        </div>
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Adminbereich</h1>
+        <p className="text-muted-foreground text-sm">Live-Betrieb und Event-Auswertung in einer Ansicht.</p>
       </div>
 
-      {/* Stat cards */}
+      <Card className="overflow-hidden border-slate-200/80">
+        <CardHeader className="pb-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Badge
+                  variant="outline"
+                  className={cn("rounded-full border px-3 py-1", statusClasses(opsOverview?.overallStatus || "green"))}
+                >
+                  <RadioTower className="mr-1 size-3.5" />
+                  {severityCopy(opsOverview?.overallStatus || "green")}
+                </Badge>
+                <span className="text-muted-foreground text-sm">Live-Betrieb jetzt</span>
+              </div>
+              <CardTitle className="text-xl">Operative Übersicht</CardTitle>
+              <CardDescription>Systemstatus und Stationsdruck separat von der Event-Auswertung.</CardDescription>
+            </div>
+            <Link href="/admin/stations" className="text-sm font-medium underline underline-offset-4">
+              Stationen verwalten
+            </Link>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {opsError && <div className="text-sm text-red-600">{opsError}</div>}
+
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {(opsOverview?.statusChips || []).map((chip) => (
+              <div key={chip.key} className={cn("rounded-2xl border px-4 py-3", statusClasses(chip.status))}>
+                <div className="text-xs font-medium tracking-[0.16em] uppercase opacity-80">{chip.label}</div>
+                <div className="mt-1 text-sm font-semibold">{chip.summary}</div>
+              </div>
+            ))}
+            {opsLoading &&
+              Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="rounded-2xl border border-dashed px-4 py-6 text-sm text-slate-500">
+                  Lade Live-Status…
+                </div>
+              ))}
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {!opsLoading && (opsOverview?.stations.length || 0) === 0 && (
+              <div className="text-muted-foreground rounded-2xl border border-dashed px-4 py-8 text-sm md:col-span-2 xl:col-span-4">
+                Keine freigegebenen Stationen vorhanden.
+              </div>
+            )}
+
+            {(opsOverview?.stations || []).map((station) => (
+              <Link key={station.id} href={`/admin/stations/${station.id}`}>
+                <div className="rounded-2xl border border-slate-200 p-4 transition-shadow hover:shadow-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="font-medium">{station.name}</div>
+                      <div className="text-muted-foreground mt-1 text-sm">
+                        {station.recentProductTitle
+                          ? `${station.recentProductTitle} · ${station.recentProductQuantity}× zuletzt`
+                          : "Keine aktuelle Produktbewegung"}
+                      </div>
+                    </div>
+                    <Badge variant="outline" className={cn("rounded-full", statusClasses(station.status))}>
+                      {severityCopy(station.status)}
+                    </Badge>
+                  </div>
+
+                  <div className="mt-4 grid grid-cols-3 gap-2 text-sm">
+                    <div className="rounded-xl bg-slate-100 px-3 py-2">
+                      <div className="text-muted-foreground text-xs">Offene</div>
+                      <div className="mt-1 font-semibold">{station.openOrders}</div>
+                    </div>
+                    <div className="rounded-xl bg-slate-100 px-3 py-2">
+                      <div className="text-muted-foreground text-xs">Backlog</div>
+                      <div className="mt-1 font-semibold">{station.backlog}</div>
+                    </div>
+                    <div className="rounded-xl bg-slate-100 px-3 py-2">
+                      <div className="text-muted-foreground text-xs">Median</div>
+                      <div className="mt-1 font-semibold">{station.medianThroughputMinutes}m</div>
+                    </div>
+                  </div>
+
+                  <div className="text-muted-foreground mt-4 flex items-center justify-between text-sm">
+                    <span>Details öffnen</span>
+                    <ArrowRight className="size-4" />
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <section className="space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Event-Auswertung</h2>
+            <p className="text-muted-foreground mt-1 text-sm">Historische Kennzahlen und Vergleiche pro Eventtag.</p>
+          </div>
+          <div className="w-full sm:w-[280px]">
+            <Select
+              value={selectedEventKey || "__empty"}
+              onValueChange={(next) => setSelectedEventKey(next === "__empty" ? "" : next)}
+              disabled={eventsLoading || events.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Eventtag wählen" />
+              </SelectTrigger>
+              <SelectContent>
+                {events.length === 0 ? (
+                  <SelectItem value="__empty">Kein Event vorhanden</SelectItem>
+                ) : (
+                  events.map((event) => (
+                    <SelectItem key={eventKey(event)} value={eventKey(event)}>
+                      {formatEventLabel(event)} · {event.orderCount} Orders
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        {!eventsLoading && selectedEvent && (
+          <div className="text-muted-foreground text-sm">Ausgewählt: {formatEventLabel(selectedEvent)}</div>
+        )}
+      </section>
+
       <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <StatCard
           title="Umsatz"
@@ -412,14 +575,12 @@ export default function AdminDashboard() {
         <StatCard title="Stornierungen" value={String(cancellationCount)} loading={loading} />
       </section>
 
-      {/* Revenue & Orders charts */}
       <section className="grid grid-cols-1 gap-4 lg:grid-cols-[2fr_1fr_1fr]">
         <RevenueByHourChart data={revenueByHour} loading={loading} />
         <PaymentMethodsChart data={paymentMethodCounts} loading={loading} />
         <OrdersByOriginChart data={ordersByOrigin} loading={loading} />
       </section>
 
-      {/* Product rankings */}
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <TopProductsChart title="Top Produkte nach Menge" data={topProductsByUnits} loading={loading} />
         <TopProductsChart
@@ -430,13 +591,11 @@ export default function AdminDashboard() {
         />
       </section>
 
-      {/* Order health */}
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <OrdersByStatusChart data={ordersByStatusByHour} loading={loading} />
         <RecentCancellations data={recentCancellations} loading={loading} />
       </section>
 
-      {/* Low stock products */}
       <section>
         <h2 className="text-xl font-semibold">Artikel mit niedrigem Bestand</h2>
         <p className="text-muted-foreground mt-1 text-sm">Produkte mit weniger als {LOW_STOCK_THRESHOLD} Einheiten</p>

--- a/bfs-web-app/app/admin/stations/[id]/page.tsx
+++ b/bfs-web-app/app/admin/stations/[id]/page.tsx
@@ -1,0 +1,217 @@
+"use client"
+
+import { Clock3 } from "lucide-react"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { useEffect, useMemo, useState } from "react"
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
+import { TopProductsChart } from "@/app/admin/_components/top-products-chart"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { type ChartConfig, ChartContainer, ChartTooltip } from "@/components/ui/chart"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { useAuthorizedFetch } from "@/hooks/use-authorized-fetch"
+import { cn } from "@/lib/utils"
+import type { DashboardStatusLevel, StationDetailSummary } from "@/types"
+
+function statusClasses(status: DashboardStatusLevel) {
+  if (status === "red") return "border-red-300 bg-red-50 text-red-800"
+  if (status === "yellow") return "border-amber-300 bg-amber-50 text-amber-900"
+  return "border-emerald-300 bg-emerald-50 text-emerald-900"
+}
+
+const throughputChartConfig = {
+  value: { label: "Fertiggestellt", color: "var(--chart-2)" },
+} satisfies ChartConfig
+
+export default function AdminStationDetailPage() {
+  const fetchAuth = useAuthorizedFetch()
+  const params = useParams<{ id: string }>()
+  const stationId = params.id || ""
+  const [summary, setSummary] = useState<StationDetailSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!stationId) return
+    let cancelled = false
+
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetchAuth(`/api/v1/stations/${stationId}/summary`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as StationDetailSummary
+        if (!cancelled) {
+          setSummary(data)
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setSummary(null)
+          setError(err instanceof Error ? err.message : "Stationsansicht konnte nicht geladen werden.")
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [fetchAuth, stationId])
+
+  const topProductsData = useMemo(
+    () => (summary?.topProducts || []).map((item) => ({ title: item.title, value: item.quantity })),
+    [summary]
+  )
+  const throughputData = useMemo(
+    () => (summary?.throughputByHour || []).map((item) => ({ hour: item.label, value: item.value })),
+    [summary]
+  )
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3">
+        <Link href="/admin" className="text-muted-foreground text-sm underline underline-offset-4">
+          Zurück zum Adminbereich
+        </Link>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-semibold">{summary?.station.name || "Station"}</h1>
+              <Badge variant="outline" className={cn("rounded-full", statusClasses(summary?.station.status || "green"))}>
+                {summary?.station.status || "green"}
+              </Badge>
+            </div>
+            <p className="text-muted-foreground text-sm">
+              Aktuelle Queue, Durchsatz seit Tagesbeginn und relevante Produkte der letzten Stunde.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-2xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Offene Orders</CardDescription>
+            <CardTitle className="text-3xl">{loading ? "–" : summary?.station.openOrders || 0}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Backlog</CardDescription>
+            <CardTitle className="text-3xl">{loading ? "–" : summary?.station.backlog || 0}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Median-Durchlaufzeit</CardDescription>
+            <CardTitle className="text-3xl">
+              {loading ? "–" : `${summary?.station.medianThroughputMinutes || 0}m`}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+        <Card className="rounded-[24px]">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Clock3 className="size-4" />
+              Aktuelle Queue
+            </CardTitle>
+            <CardDescription>Die ältesten und dichtesten offenen Orders zuerst.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {(summary?.queue.length || 0) === 0 && !loading ? (
+              <div className="text-muted-foreground rounded-2xl border border-dashed px-4 py-10 text-center text-sm">
+                Keine offene Queue seit Tagesbeginn.
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Order</TableHead>
+                      <TableHead>Alter</TableHead>
+                      <TableHead>Items</TableHead>
+                      <TableHead>Menge</TableHead>
+                      <TableHead>Artikel</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(summary?.queue || []).map((item) => (
+                      <TableRow key={item.orderId}>
+                        <TableCell>
+                          <Link href={`/admin/orders/${item.orderId}`} className="underline underline-offset-4">
+                            {item.orderId.slice(0, 8)}…
+                          </Link>
+                        </TableCell>
+                        <TableCell>{item.ageMinutes}m</TableCell>
+                        <TableCell>{item.pendingItems}</TableCell>
+                        <TableCell>{item.pendingQuantity}</TableCell>
+                        <TableCell className="max-w-[320px] truncate">{item.titles.join(", ")}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          <Card className="rounded-[24px]">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Clock3 className="size-4" />
+                Fertigstellungen pro Stunde
+              </CardTitle>
+              <CardDescription>Abgeschlossene Mengen dieser Station seit Tagesbeginn.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <div className="text-muted-foreground flex h-[220px] items-center justify-center text-sm">Lade…</div>
+              ) : throughputData.length === 0 ? (
+                <div className="text-muted-foreground flex h-[220px] items-center justify-center rounded-2xl border border-dashed text-sm">
+                  Noch keine Fertigstellungen vorhanden.
+                </div>
+              ) : (
+                <ChartContainer config={throughputChartConfig} className="h-[220px] w-full">
+                  <BarChart data={throughputData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                    <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                    <XAxis dataKey="hour" tickLine={false} axisLine={false} fontSize={12} />
+                    <YAxis tickLine={false} axisLine={false} fontSize={12} width={32} />
+                    <ChartTooltip
+                      content={({ active, payload }) => {
+                        if (!active || !payload?.length || !payload[0]) return null
+                        const point = payload[0].payload as { hour: string; value: number }
+                        return (
+                          <div className="border-border/50 bg-background rounded-lg border px-3 py-2 text-xs shadow-xl">
+                            <div className="font-medium">{point.hour} Uhr</div>
+                            <div className="text-muted-foreground">{point.value}× fertiggestellt</div>
+                          </div>
+                        )
+                      }}
+                    />
+                    <Bar dataKey="value" fill="var(--color-value)" radius={[4, 4, 0, 0]} />
+                  </BarChart>
+                </ChartContainer>
+              )}
+            </CardContent>
+          </Card>
+
+          <TopProductsChart title="Top-Produkte der letzten Stunde" data={topProductsData} loading={loading} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/bfs-web-app/types/admin-dashboard.ts
+++ b/bfs-web-app/types/admin-dashboard.ts
@@ -1,0 +1,52 @@
+export type DashboardStatusLevel = "green" | "yellow" | "red"
+
+export interface SystemStatusChip {
+  key: string
+  label: string
+  status: DashboardStatusLevel
+  summary: string
+}
+
+export interface StationOverviewCard {
+  id: string
+  name: string
+  status: DashboardStatusLevel
+  openOrders: number
+  backlog: number
+  medianThroughputMinutes: number
+  recentProductTitle?: string | null
+  recentProductQuantity: number
+}
+
+export interface AdminOpsOverview {
+  overallStatus: DashboardStatusLevel
+  statusChips: SystemStatusChip[]
+  stations: StationOverviewCard[]
+}
+
+export interface DashboardTopProductWindowItem {
+  title: string
+  quantity: number
+  revenueCents: number
+}
+
+export interface DashboardSeriesPoint {
+  label: string
+  value: number
+}
+
+export interface StationQueueMetric {
+  orderId: string
+  createdAt: string
+  ageMinutes: number
+  pendingItems: number
+  pendingQuantity: number
+  titles: string[]
+}
+
+export interface StationDetailSummary {
+  station: StationOverviewCard
+  queue: StationQueueMetric[]
+  topProducts: DashboardTopProductWindowItem[]
+  throughputByHour: DashboardSeriesPoint[]
+}

--- a/bfs-web-app/types/index.ts
+++ b/bfs-web-app/types/index.ts
@@ -6,6 +6,16 @@ export type { ProductType, Product, ProductSummaryDTO, ProductDTO } from "./prod
 export type { Menu, MenuSlot, MenuSlotOption, MenuSlotDTO, MenuSlotItem, MenuSlotItemDTO, MenuDTO } from "./menu"
 export type { OrderStatus, Order, OrderItemType, OrderItem } from "./order"
 export type { AdminInviteStatus, AdminInvite } from "./admin"
+export type {
+  DashboardStatusLevel,
+  SystemStatusChip,
+  AdminOpsOverview,
+  DashboardTopProductWindowItem,
+  StationOverviewCard,
+  DashboardSeriesPoint,
+  StationQueueMetric,
+  StationDetailSummary,
+} from "./admin-dashboard"
 export type { InventoryReason, InventoryLedger } from "./inventory"
 export type { CartItemConfiguration, CartItem, Cart, CartContextType } from "./cart"
 export type { Jeton, PosFulfillmentMode, PosSettings } from "./jeton"


### PR DESCRIPTION
Hellou

ich wollte die Admin-Auswertung etwas verbessern, ohne das bestehende Dashboard gross umzubauen. Darum bleibt die bisherige Event-Auswertung wie sie ist, und neu kommt nur eine kleine Live-Ops-Sektion dazu mit aktuellem Status, Stationsübersicht und einer kompakten Stations-Detailseite für den laufenden Betrieb.

Im Backend sind dafür nur zwei read-only Endpoints dazugekommen: `GET /api/v1/dashboard/ops-overview` und `GET /api/v1/stations/{stationId}/summary`. Grössere fachliche Änderungen wie Anpassungen an der Stations-Produktzuordnung habe ich bewusst nicht mitgenommen.

Lokal geprüft habe ich `go test ./internal/service/... ./internal/api/...` sowie `corepack pnpm typecheck`.

Bitte schau es dir trotzdem noch kurz kritisch an und teste es einmal selbst durch, nicht dass mein Vibecode-Slop deinen schönen Code kaputt macht ;)
