### PR TITLE
chore: add NotEmpty to required entity id foreign keys

### DIFF
--- a/bfs-backend/internal/schema/club100_free_product.go
+++ b/bfs-backend/internal/schema/club100_free_product.go
@@ -23,7 +23,8 @@ func (Club100FreeProduct) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("settings_id").MaxLen(50),
 		field.String("product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 	}
 }
 

--- a/bfs-backend/internal/schema/club100_redemption.go
+++ b/bfs-backend/internal/schema/club100_redemption.go
@@ -30,7 +30,8 @@ func (Club100Redemption) Fields() []ent.Field {
 			MaxLen(100).
 			NotEmpty(),
 		field.String("order_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.Int("free_product_quantity").
 			Default(1),
 		field.Time("created_at").

--- a/bfs-backend/internal/schema/device_product.go
+++ b/bfs-backend/internal/schema/device_product.go
@@ -22,9 +22,11 @@ func (DeviceProduct) Annotations() []schema.Annotation {
 func (DeviceProduct) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("device_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.String("product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 	}
 }
 

--- a/bfs-backend/internal/schema/inventory_ledger.go
+++ b/bfs-backend/internal/schema/inventory_ledger.go
@@ -24,7 +24,8 @@ func (InventoryLedger) Fields() []ent.Field {
 	return []ent.Field{
 		nanoidPK(),
 		field.String("product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.Int("delta"),
 		field.Enum("reason").
 			Values("opening_balance", "sale", "refund", "cancellation", "manual_adjust", "correction").

--- a/bfs-backend/internal/schema/menu_slot.go
+++ b/bfs-backend/internal/schema/menu_slot.go
@@ -22,7 +22,8 @@ func (MenuSlot) Fields() []ent.Field {
 	return []ent.Field{
 		nanoidPK(),
 		field.String("menu_product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.String("name").
 			MaxLen(20).
 			NotEmpty(),

--- a/bfs-backend/internal/schema/menu_slot_option.go
+++ b/bfs-backend/internal/schema/menu_slot_option.go
@@ -22,9 +22,11 @@ func (MenuSlotOption) Annotations() []schema.Annotation {
 func (MenuSlotOption) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("menu_slot_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.String("option_product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 	}
 }
 

--- a/bfs-backend/internal/schema/order_line_redemption.go
+++ b/bfs-backend/internal/schema/order_line_redemption.go
@@ -25,6 +25,7 @@ func (OrderLineRedemption) Fields() []ent.Field {
 		nanoidPK(),
 		field.String("order_line_id").
 			MaxLen(36).
+			NotEmpty().
 			Unique(),
 		field.Time("redeemed_at").
 			Default(time.Now),

--- a/bfs-backend/internal/schema/order_payment.go
+++ b/bfs-backend/internal/schema/order_payment.go
@@ -24,7 +24,8 @@ func (OrderPayment) Fields() []ent.Field {
 	return []ent.Field{
 		nanoidPK(),
 		field.String("order_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.Enum("method").
 			Values("CASH", "CARD", "TWINT", "GRATIS_GUEST", "GRATIS_VIP", "GRATIS_STAFF", "GRATIS_100CLUB").
 			StorageKey("method"),

--- a/bfs-backend/internal/schema/volunteer_campaign_product.go
+++ b/bfs-backend/internal/schema/volunteer_campaign_product.go
@@ -22,9 +22,11 @@ func (VolunteerCampaignProduct) Annotations() []schema.Annotation {
 func (VolunteerCampaignProduct) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("campaign_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.String("product_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.Int("quantity").
 			Default(1),
 	}

--- a/bfs-backend/internal/schema/volunteer_redemption.go
+++ b/bfs-backend/internal/schema/volunteer_redemption.go
@@ -25,9 +25,11 @@ func (VolunteerRedemption) Fields() []ent.Field {
 	return []ent.Field{
 		nanoidPK(),
 		field.String("campaign_id").
-			MaxLen(36),
+			MaxLen(36).
+			NotEmpty(),
 		field.String("order_id").
 			MaxLen(36).
+			NotEmpty().
 			Unique(),
 		field.String("station_device_id").
 			MaxLen(36).


### PR DESCRIPTION
Follow-up to the nanoid id migration (#366).

The migration's required (NOT NULL) entity-id foreign-key fields were only partially given `.NotEmpty()` (a Copilot review added it to `order_line.order_id`, `order_line.product_id`, and `product.category_id`). This applies it uniformly to the remaining required entity-FK string fields so an empty id fails fast as a validation error instead of reaching a DB foreign-key violation.

Fields updated: `menu_slot.menu_product_id`, `order_payment.order_id`, `inventory_ledger.product_id`, `club100_redemption.order_id`, `club100_free_product.product_id`, `order_line_redemption.order_line_id`, `menu_slot_option.{menu_slot_id,option_product_id}`, `device_product.{device_id,product_id}`, `volunteer_campaign_product.{campaign_id,product_id}`, `volunteer_redemption.{campaign_id,order_id}`.

Optional/nullable FK fields and user-id (Better Auth) fields are intentionally left unchanged. No migration needed — `NotEmpty()` is an application-level validator; the columns are already NOT NULL.

Verified: `go build`, golangci-lint (0 issues), `go test ./internal/...` all pass.